### PR TITLE
Added a flake.nix for portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Convert a laptop, desktop or second Raspberry Pi into a Knight TV or DEC VT-52 t
 <br>
 Supports:
 - Linux X86_64 (Ubuntu)
+- NixOS (with flake.nix)
+- Mac OS X (with flake.nix)
 - Windows 11 with WSL subsystem (Ubuntu)
 - Raspberry Pi (Bookworm 64 bit)
-<br>
+<br><br>
 Included terminal simulators:
 - Knight TV
 - DEC VT-52
@@ -55,10 +57,27 @@ Don't forget, if you want to switch Teletypes in mid-flight, leave the first Tel
   
 # Warning...
 
-Note: very early beta version, and this version particularly *depends on your system using the apt package manager* (Ubuntu, Debian). 
-<br>Edit install-rpdp.sh to use any other package manager.
-<br>
+Note: very early beta version. This version is usable on Debian-based GNU/Linux distributions (using apt), or a system running Nix with Flakes enabled. The flake.nix has been tested on NixOS 24.11 and an M3 MacBook Pro running macOS 15 Sequoia, though there is no reason to suppose that a Windows system with WSL2 could not also work.
+
+## Install scripts
+Edit install-rpdp.sh to use any other package manager.
+<br><br>
 So far, only tested on Ubuntu 22.04. Let me know of any problems on other systems.
-There's been confirmation that the incuded binaries work on Windows 11 with WSL subsystem (Ubuntu). The bin/pdp.sh has not been tested on Windows yet though. Feedback requested!
-<br>
+There's been confirmation that the included binaries work on Windows 11 with WSL subsystem (Ubuntu). The bin/pdp.sh has not been tested on Windows yet though. Feedback requested!
+<br><br>
 The install script assumes /usr/local/bin is an existing directory, in your PATH. Otherwise, the command 'pdp' will not be found; in that case try '/opt/rpdp/bin/rpdp.sh ?' to see if that works.
+
+## flake.nix
+The "easy button" is to simply run `nix shell` in the root of the repo after setting `pidpremote` and `piuser` in 
+flake.nix. However, you can also use `nix profile install`. From there, all the commands work exactly as described above in the Terminals section.
+<br><br>
+The flake.nix file is designed for maximum flexibility, and individual build targets can be built and tested.
+
+### Differences from the apt version
+Notably, the Imlac emulator is absent. The primary author of flake.nix (to-lose-letrec) is having trouble getting it to compile properly. Help is welcome if you know your way around Nix!
+<br><br>
+Rather than using `lxterminal` for `telcon`, `xterm` is used. The latter is more likely to be installed by default on some systems, and is sure to be installed on Mac OS X if `XQuartz` is used (this is also the recommended configuration there).
+<br><br>
+Also, the sty33 program compiles and runs as expected, but the font is up to you to install. The author recommends using `home-manager` for managing individual user configurations, but simply copying it to `$HOME/.local/share/fonts` or `$HOME/.fonts` and running `fc-cache -v -f` is all that is strictly necessary.
+<br><br>
+`supdup` is also included in this version.

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ flake.nix. However, you can also use `nix profile install`. From there, all the 
 The flake.nix file is designed for maximum flexibility, and individual build targets can be built and tested.
 
 ### Differences from the apt version
-Notably, the Imlac emulator is absent. The primary author of flake.nix (to-lose-letrec) is having trouble getting it to compile properly. Help is welcome if you know your way around Nix!
-<br><br>
 Rather than using `lxterminal` for `telcon`, `xterm` is used. The latter is more likely to be installed by default on some systems, and is sure to be installed on Mac OS X if `XQuartz` is used (this is also the recommended configuration there).
 <br><br>
 Also, the `sty33` program compiles and runs as expected, but the font is up to you to install. The author recommends using `home-manager` for managing individual user configurations, but simply copying it to `$HOME/.local/share/fonts` or `$HOME/.fonts` and running `fc-cache -v -f` is all that is strictly necessary.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ Notably, the Imlac emulator is absent. The primary author of flake.nix (to-lose-
 <br><br>
 Rather than using `lxterminal` for `telcon`, `xterm` is used. The latter is more likely to be installed by default on some systems, and is sure to be installed on Mac OS X if `XQuartz` is used (this is also the recommended configuration there).
 <br><br>
-Also, the sty33 program compiles and runs as expected, but the font is up to you to install. The author recommends using `home-manager` for managing individual user configurations, but simply copying it to `$HOME/.local/share/fonts` or `$HOME/.fonts` and running `fc-cache -v -f` is all that is strictly necessary.
+Also, the `sty33` program compiles and runs as expected, but the font is up to you to install. The author recommends using `home-manager` for managing individual user configurations, but simply copying it to `$HOME/.local/share/fonts` or `$HOME/.fonts` and running `fc-cache -v -f` is all that is strictly necessary.
 <br><br>
 `supdup` is also included in this version.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1740828860,
+        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,7 @@
 
                     # And now to do some dodgy things to config.mk.
                     sed -i 's/-lrt//' $SRC/config.mk
+                    sed -i 's/,--allow-shlib-undefined//' $SRC/config.mk
                     sed -i -e 's/PKG_CONFIG = pkg-config//; /# Customize below to fit your system/a\' \
                     -e 'PKG_CONFIG = pkg-config \
                     CFLAGS := $(CFLAGS) `$(PKG_CONFIG) --cflags sdl2 SDL2_image SDL2_mixer SDL2_ttf` \
@@ -144,7 +145,7 @@ if [ $# -eq 0 ]; then
     ssh -t ${piuser}@${pidpremote} 'pdp'
 else
     case $1 in
-	      con)
+        con)
             nohup sty -e telnet ${pidpremote} 1025 > /dev/null 2>&1 &
             ;;
         telcon)
@@ -155,19 +156,19 @@ else
             ;;
         tvcon)
             nohup tvcon -2BS ${pidpremote} > /dev/null 2>&1 &
-  			    ;;
-  		  tek)
-            nohup tek4010 -b9600 telnet ${pidpremote} 10017 > /dev/null 2>&1 &
-  			    ;;
-  		  dp3300)
-  			    nohup dp3300 -a -B telnet ${pidpremote} 10020 > /dev/null 2>&1 &	
-  			    ;;
-  		  *)
-  			    echo rpdp for remote PiDP-10. Options are: 
-   			    echo  [con telcon vt52 tvcon tek dp3300 ]
-  			    echo when run without options, 
-  			    echo  pdp brings you into simh - Ctrl-A d to leave.
-  			    echo
+            ;;
+        tek)
+            nohup tek4010 -b9600 telnet ${pidpremote} 10017 > /dev/null 2>&1
+            ;;
+        dp3300)
+            nohup dp3300 -a -B telnet ${pidpremote} 10020 > /dev/null 2>&1 &
+            ;;
+        *)
+            echo rpdp for remote PiDP-10. Options are:
+            echo  [con telcon vt52 tvcon tek dp3300 ]
+            echo when run without options,
+            echo  pdp brings you into simh - Ctrl-A d to leave.
+            echo
             echo edit flake.nix to change hostname and username 
             echo for your PiDP-10.
             ;;

--- a/flake.nix
+++ b/flake.nix
@@ -103,14 +103,14 @@
                     xorg.libXft
                   ];
                   nativeBuildInputs = [
-                    fontconfig
-                    freetype
-                    gnumake
-                    pkg-config
                     SDL2
                     SDL2_image
                     SDL2_mixer
                     SDL2_ttf
+                    fontconfig
+                    freetype
+                    gnumake
+                    pkg-config
                   ];
                   patchPhase = ''
                     # For our first order of business, the sounds

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
                     SDL2_mixer
                     SDL2_net
                     SDL2_ttf
+                    gcc
                     iconv
                     libpcap
                     libpng

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,196 @@
+{
+  description = "A Nix Flake for PiDP-10 utility software.";
+
+  # This can and should be modified if you want to use a
+  # different channel.
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+
+      # Change the below values for your own setup!
+      pidpremote = "XXX.XXX.XXX.XXX"; 
+      piuser = "pi";
+    in
+      {
+        packages = forAllSystems (system:
+          let
+            pkgs = nixpkgsFor.${system};
+
+            stdBuild = "make -j $NIX_BUILD_CORES $pname";
+            stdInstall = "mkdir -p $out/bin; mv $pname $out/bin";
+          in
+            (with pkgs;
+              {
+                dp3300 = stdenv.mkDerivation {
+                  pname = "dp3300";
+                  version = "1.0";
+                  src = fetchgit {
+                    url = "https://github.com/aap/vt05";
+                    sha256 = "sha256-4k90WvcBChZi3zHiCreWNVEEy2qmlG/dBQz2Uqv/GYM=";
+                  };
+                  nativeBuildInputs = [ gnumake SDL2 ];
+                  buildPhase = stdBuild;
+                  installPhase = stdInstall;
+                };
+
+                sty = stdenv.mkDerivation {
+                  pname = "sty";
+                  version = "0.9";
+                  src = fetchgit {
+                    url = "https://github.com/obsolescence/pidp10";
+                    sha256 = "sha256-EPp6ziR5CaTFzigoLLew8fGjBNy9h8SKi6VsEEiu01Q=";
+                  };
+                  buildInputs = [
+                    xorg.libX11
+                    xorg.libXft
+                  ];
+                  nativeBuildInputs = [
+                    fontconfig
+                    freetype
+                    gnumake
+                    pkg-config
+                    SDL2
+                    SDL2_image
+                    SDL2_mixer
+                    SDL2_ttf
+                  ];
+                  patchPhase = ''
+                    # For our first order of business, the sounds
+                    # have to live somewhere, but we have no /opt.
+                    SRC=src/sty33
+                    NIX_DEST=$out/sounds
+
+                    # Since the WAV locations were hard-coded,
+                    # we need to update them.
+                    sed -i "s,/opt/pidp10/bin/sounds,$NIX_DEST,g" $SRC/sounds.c
+
+                    # And now to do some dodgy things to config.mk.
+                    sed -i 's/-lrt//' $SRC/config.mk
+                    sed -i -e 's/PKG_CONFIG = pkg-config//; /# Customize below to fit your system/a\' \
+                    -e 'PKG_CONFIG = pkg-config \
+                    CFLAGS := $(CFLAGS) `$(PKG_CONFIG) --cflags sdl2 SDL2_image SDL2_mixer SDL2_ttf` \
+                    LDFLAGS := $(LDFLAGS) `$(PKG_CONFIG) --libs sdl2 SDL2_image SDL2_mixer SDL2_ttf`' $SRC/config.mk
+                  '';
+                  buildPhase = ''
+                    mkdir -p $NIX_DEST
+
+                    cd $SRC
+                    cp sounds/*.wav $NIX_DEST
+
+                    make -j $NIX_BUILD_CORES
+                  '';
+                  installPhase = stdInstall;
+                };
+
+                supdup = stdenv.mkDerivation {
+                  pname = "supdup";
+                  version = "1.0";
+                  src = fetchgit {
+                    url = "https://github.com/PDP-10/supdup";
+                    sha256 = "sha256-5ep1/czMay3hq1VFD75ljVvSgcHMVEJJx3tyfv0ywaI=";
+                  };
+                  nativeBuildInputs = [ gnumake ncurses pkg-config ];
+                  buildPhase = stdBuild;
+                  installPhase = stdInstall;
+                };
+
+                tek4010 = stdenv.mkDerivation {
+                  pname = "tek4010";
+                  version = "1.0";
+                  src = fetchgit {
+                    url = "https://github.com/rricharz/Tek4010";
+                    sha256 = "sha256-4QTbCR+AC8dp9eIOfqoQWRh8JmU3Ivce3HEQT1qWoSw=";
+                  };
+                  nativeBuildInputs = [ cairo gnumake gtk3 pkg-config ];
+                  buildPhase = stdBuild;
+                  installPhase = stdInstall;
+                };              
+
+                tvcon = stdenv.mkDerivation {
+                  pname = "tvcon";
+                  version = "1.0";
+	                src = fetchgit {
+	                  url = "https://github.com/aap/pdp11";
+                    sha256 = "sha256-qLRuIzE+r/8L7J/IqVNZ5EX5rblpLxp+aOcTdCkxsuc=";
+                  };
+                  nativeBuildInputs = [ gnumake SDL2 SDL2_net ];
+                  prePatch = "cd tvcon";
+                  buildPhase = stdBuild;
+                  installPhase = stdInstall;
+                };
+
+                vt52 = stdenv.mkDerivation {
+                  pname = "vt52";
+                  version = "1.0";
+                  src = fetchgit {
+                    url = "https://github.com/aap/vt05";
+                    sha256 = "sha256-4k90WvcBChZi3zHiCreWNVEEy2qmlG/dBQz2Uqv/GYM=";
+                  };
+                  nativeBuildInputs = [ gnumake SDL2 ];
+                  buildPhase = stdBuild;
+                  installPhase = stdInstall;
+                };
+
+                rpdp = pkgs.writeShellScriptBin "rpdp" ''
+echo "remote connection to ${pidpremote}"
+
+if [ $# -eq 0 ]; then
+    echo "ssh into ${pidpremote}. Assumes the PDP-10 simulation is indeed running."
+    echo "opening virtual screen terminal, Ctrl-A d to leave."
+    ssh -t ${piuser}@${pidpremote} 'pdp'
+else
+    case $1 in
+	      con)
+            nohup sty -e telnet ${pidpremote} 1025 > /dev/null 2>&1 &
+            ;;
+        telcon)
+            nohup xterm -e "telnet ${pidpremote} 1025" > /dev/null 2>&1 &
+            ;;
+        vt52)
+            nohup vt52 -B telnet ${pidpremote} 10018 > /dev/null 2>&1 &
+            ;;
+        tvcon)
+            nohup tvcon -2BS ${pidpremote} > /dev/null 2>&1 &
+  			    ;;
+  		  tek)
+            nohup tek4010 -b9600 telnet ${pidpremote} 10017 > /dev/null 2>&1 &
+  			    ;;
+  		  dp3300)
+  			    nohup dp3300 -a -B telnet ${pidpremote} 10020 > /dev/null 2>&1 &	
+  			    ;;
+  		  *)
+  			    echo rpdp for remote PiDP-10. Options are: 
+   			    echo  [con telcon vt52 tvcon tek dp3300 ]
+  			    echo when run without options, 
+  			    echo  pdp brings you into simh - Ctrl-A d to leave.
+  			    echo
+            echo edit flake.nix to change hostname and username 
+            echo for your PiDP-10.
+            ;;
+    esac
+fi
+                '';              
+
+                nix-rpdp = symlinkJoin {
+                  name = "nix-rpdp";
+                  paths = [
+                    inetutils
+                  
+                    self.packages.${system}.dp3300
+                    self.packages.${system}.rpdp
+                    self.packages.${system}.sty                  
+                    self.packages.${system}.supdup                  
+                    self.packages.${system}.tek4010                  
+                    self.packages.${system}.tvcon
+                    self.packages.${system}.vt52
+                  ];
+                };
+              
+                default = self.packages.${system}.nix-rpdp;
+              }));
+      };
+}


### PR DESCRIPTION
# Rationale

Nix has the merit of running on most any GNU/Linux distribution as well as Mac OS X (to a more limited degree). Being a NixOS user, I thought this would be an easy way of expanding `rpdp` beyond its current state.

I have tested and used this Flake pretty rigorously with the environments I have, though of course feedback, suggestions, and changes are welcome. The README has been updated to document the additions.

# Caveats

I make no guarantees that this is the best possible configuration or that it's even done exactly right, but it works. :) 

Update: The Imlac emulator now works as expected on NixOS and Mac.